### PR TITLE
Fixed issue with new line breaking translate on screen keyboard

### DIFF
--- a/scripts/extras/translate.lua
+++ b/scripts/extras/translate.lua
@@ -112,10 +112,11 @@ function translate()
                 current = CUSTOM_TRANSLATION[t_need[scroll.sel]]
             elseif CURRENT_TRANSLATION[t_need[scroll.sel]] ~= "" then
                 current = CURRENT_TRANSLATION[t_need[scroll.sel]]
-            else
             end
 
-            local new = osk.init(ENGLISH_US[t_need[scroll.sel]], current)
+            current = string.gsub(current, "\n", "\\n")
+
+            local new = osk.init(string.gsub(ENGLISH_US[t_need[scroll.sel]], "\n", "\\n"), current)
             CUSTOM_TRANSLATION[t_need[scroll.sel]] = new
 
             if new ~= "" then


### PR DESCRIPTION
I fixed the problem that caused Autoplugin to hang when translating a string that had a "\n" in it by replacing \n with \\n. It turns out that the on screen keyboard renders "\\n" as "\n" so there were no problems in doing this and it doesn't require the translator to do anything weird. Win!